### PR TITLE
fix!: rename utils http functions

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -104,14 +104,14 @@ const response = await http.ipfsGet(request, context)
 
 ---
 
-### `http.httpCarGet`
+### `http.carGet`
 
 Gets trustless content behind IPFS CID as a CAR file.
 
 ```js
 import { http } from '@hash-stream/utils/trustless-ipfs-gateway'
 
-const response = await http.httpCarGet(request, context)
+const response = await http.carGet(request, context)
 ```
 
 **Parameters:**
@@ -123,14 +123,14 @@ const response = await http.httpCarGet(request, context)
 
 ---
 
-### `http.httpRawGet`
+### `http.rawGet`
 
 Gets trustless content behind IPFS CID as raw bytes.
 
 ```js
 import { http } from '@hash-stream/utils/trustless-ipfs-gateway'
 
-const response = await http.httpRawGet(request, context)
+const response = await http.rawGet(request, context)
 ```
 
 **Parameters:**

--- a/packages/utils/src/trustless-ipfs-gateway/http.js
+++ b/packages/utils/src/trustless-ipfs-gateway/http.js
@@ -12,14 +12,14 @@ import * as cidUtils from './cid.js'
  * @param {{ hashStreamer: import('@hash-stream/streamer').HashStreamer }} context - Context object providing the hash streamer.
  * @returns {Promise<Response>} HTTP Response containing the CAR stream or error.
  */
-export async function httpipfsGet(request, context) {
+export async function ipfsGet(request, context) {
   const format = resolveRequestedFormat(request)
 
   switch (format) {
     case 'car':
-      return await httpCarGet(request, context)
+      return await carGet(request, context)
     case 'raw':
-      return await httpRawGet(request, context)
+      return await rawGet(request, context)
     default:
       return new Response('not acceptable format', { status: 406 })
   }
@@ -32,7 +32,7 @@ export async function httpipfsGet(request, context) {
  * @param {{ hashStreamer: import('@hash-stream/streamer').HashStreamer }} context - Context object providing the hash streamer.
  * @returns {Promise<Response>} HTTP Response containing the CAR stream or error.
  */
-export async function httpCarGet(request, context) {
+export async function carGet(request, context) {
   let cid
   let carResponseOptions
 
@@ -120,7 +120,7 @@ function concatBytes(chunks) {
  * @param {{ hashStreamer: import('@hash-stream/streamer').HashStreamer }} context - Context object providing the hash streamer.
  * @returns {Promise<Response>} HTTP Response containing the raw content or an error.
  */
-export async function httpRawGet(request, context) {
+export async function rawGet(request, context) {
   /** @type {import('multiformats').CID} */
   let cid
   try {

--- a/packages/utils/test/trustless-ipfs-gateway/http.test.js
+++ b/packages/utils/test/trustless-ipfs-gateway/http.test.js
@@ -23,9 +23,9 @@ import {
 import {
   buildCarHTTPResponse,
   buildRawHTTPResponse,
-  httpipfsGet,
-  httpRawGet,
-  httpCarGet,
+  ipfsGet,
+  rawGet,
+  carGet,
 } from '../../src/trustless-ipfs-gateway/http.js'
 import { identityCid } from '../../src/trustless-ipfs-gateway/cid.js'
 
@@ -86,7 +86,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpipfsGet(request, { hashStreamer })
+    const response = await ipfsGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 200)
     assert.strictEqual(
@@ -121,7 +121,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpipfsGet(request, { hashStreamer })
+    const response = await ipfsGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 200)
     assert.strictEqual(
@@ -156,7 +156,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpipfsGet(request, { hashStreamer })
+    const response = await ipfsGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 406)
   })
@@ -169,7 +169,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpipfsGet(request, { hashStreamer })
+    const response = await ipfsGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 200)
     assert.strictEqual(
@@ -187,7 +187,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpipfsGet(request, { hashStreamer })
+    const response = await ipfsGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 200)
     assert.strictEqual(
@@ -240,7 +240,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpRawGet(request, { hashStreamer })
+    const response = await rawGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 200)
     assert.strictEqual(
@@ -290,7 +290,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpCarGet(request, { hashStreamer })
+    const response = await carGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 200)
     assert.strictEqual(
@@ -339,7 +339,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpCarGet(request, { hashStreamer })
+    const response = await carGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 400)
   })
@@ -353,7 +353,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpRawGet(request, { hashStreamer })
+    const response = await rawGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 400)
   })
@@ -367,7 +367,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpCarGet(request, { hashStreamer })
+    const response = await carGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 400)
   })
@@ -381,7 +381,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpCarGet(request, { hashStreamer })
+    const response = await carGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 404)
   })
@@ -395,7 +395,7 @@ describe(`trustless ipfs gateway http utils`, () => {
       },
     })
 
-    const response = await httpRawGet(request, { hashStreamer })
+    const response = await rawGet(request, { hashStreamer })
     assert(response)
     assert.strictEqual(response.status, 404)
   })


### PR DESCRIPTION
BREAKING CHANGE: httpCarGet and httpRawGet function names renamed