### PR TITLE
fix: schedule store files for indexing with files generator

### DIFF
--- a/docs/src/content/docs/api/@hash-stream/index-pipeline/functions/processFileForIndexing.md
+++ b/docs/src/content/docs/api/@hash-stream/index-pipeline/functions/processFileForIndexing.md
@@ -7,7 +7,7 @@ title: "processFileForIndexing"
 
 > **processFileForIndexing**(`fileStore`, `indexWriters`, `indexFormat`, `fileReference`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`undefined` \| `MultihashDigest`\<`number`\>\>
 
-Defined in: [index.js:50](https://github.com/vasco-santos/hash-stream/blob/main/packages/index-pipeline/src/index.js#L50)
+Defined in: [index.js:52](https://github.com/vasco-santos/hash-stream/blob/main/packages/index-pipeline/src/index.js#L52)
 
 Scheduler consumer function where a file reference is fetched from the store,
 processed, and then written to the index store.

--- a/docs/src/content/docs/api/@hash-stream/index-pipeline/functions/scheduleStoreFilesForIndexing.md
+++ b/docs/src/content/docs/api/@hash-stream/index-pipeline/functions/scheduleStoreFilesForIndexing.md
@@ -5,9 +5,9 @@ prev: true
 title: "scheduleStoreFilesForIndexing"
 ---
 
-> **scheduleStoreFilesForIndexing**(`fileStore`, `indexScheduler`, `options`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
+> **scheduleStoreFilesForIndexing**(`fileStore`, `indexScheduler`, `options`): `AsyncIterable`\<`string`, `any`, `any`\>
 
-Defined in: [index.js:22](https://github.com/vasco-santos/hash-stream/blob/main/packages/index-pipeline/src/index.js#L22)
+Defined in: [index.js:23](https://github.com/vasco-santos/hash-stream/blob/main/packages/index-pipeline/src/index.js#L23)
 
 Function that prepares files for indexing by listing them in the file store
 and sending a reference of each file to an Index scheduler.
@@ -25,4 +25,4 @@ simple HTTP endpoint that accepts file references for processing.
 
 ## Returns
 
-[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
+`AsyncIterable`\<`string`, `any`, `any`\>

--- a/packages/index-pipeline/README.md
+++ b/packages/index-pipeline/README.md
@@ -29,6 +29,7 @@ import {
   scheduleStoreFilesForIndexing,
   processFileForIndexing
 } from '@hash-stream/index-pipeline/index'
+import all from 'it-all'
 
 import { MemoryFileStore } from '@hash-stream/index-pipeline/file-store/memory'
 import { MemoryIndexScheduler } from '@hash-stream/index-pipeline/index-scheduler/memory'
@@ -37,7 +38,7 @@ const fileStore = new MemoryFileStore([...])
 const scheduler = new MemoryIndexScheduler([])
 
 // Schedule all files for indexing
-await scheduleStoreFilesForIndexing(fileStore, scheduler)
+await all(scheduleStoreFilesForIndexing(fileStore, scheduler))
 
 // Consume and process tasks
 for await (const task of scheduler.drain()) {
@@ -56,6 +57,10 @@ Lists all files from a `FileStore` and schedules them via an `IndexScheduler`.
 * `fileStore`: an object implementing `FileStore`
 * `indexScheduler`: an object implementing `IndexScheduler`
 * `options.format`: index format (defaults to `'unixfs'`)
+
+Returns:
+
+* `AsyncIterable<string>` with files scheduled for indexing
 
 ### `processFileForIndexing(fileStore, indexWriters, indexFormat, fileReference, options?)`
 

--- a/packages/index-pipeline/src/index.js
+++ b/packages/index-pipeline/src/index.js
@@ -18,8 +18,9 @@ import { withMaxChunkSize } from '@ipld/unixfs/file/chunker/fixed'
  * @param {API.FileStore} fileStore
  * @param {API.IndexScheduler} indexScheduler
  * @param {API.ScheduleStoreFilesOptions} options
+ * @returns {AsyncIterable<string>}
  */
-export async function scheduleStoreFilesForIndexing(
+export async function* scheduleStoreFilesForIndexing(
   fileStore,
   indexScheduler,
   options = {}
@@ -30,6 +31,7 @@ export async function scheduleStoreFilesForIndexing(
       format,
       size: fileMetadata.size,
     })
+    yield fileMetadata.key
   }
 }
 

--- a/packages/index-pipeline/test/index.js
+++ b/packages/index-pipeline/test/index.js
@@ -86,7 +86,14 @@ export function runIndexPipelineTests(
       scheduler = await createIndexScheduler(2)
 
       // Step 1: Schedule
-      await scheduleStoreFilesForIndexing(fileStore, scheduler)
+      const scheduledItems = await all(
+        scheduleStoreFilesForIndexing(fileStore, scheduler)
+      )
+      assert(scheduledItems)
+      assert.equal(scheduledItems.length, testFiles.length)
+      for (const scheduledItem of scheduledItems) {
+        assert(testFiles.find((testFile) => testFile.key === scheduledItem))
+      }
 
       // Step 2: Drain & Index
       const indexedFiles = []


### PR DESCRIPTION
Make it possible to track the scheduler work by yielding the scheduled files