### PR TITLE
fix: return type for unixfs write file link index

### DIFF
--- a/packages/index-pipeline/src/api.ts
+++ b/packages/index-pipeline/src/api.ts
@@ -1,8 +1,9 @@
 import { BlobLike } from '@web3-storage/upload-client/types'
+import { MultihashDigest } from '@hash-stream/utils/index/types'
 
 import { CreateUnixFsFileLikeStreamOptions } from '@hash-stream/utils/index/types'
 
-export type { BlobLike }
+export type { BlobLike, MultihashDigest }
 
 export interface FileMetadata {
   key: string

--- a/packages/index-pipeline/src/index.js
+++ b/packages/index-pipeline/src/index.js
@@ -48,6 +48,7 @@ export async function* scheduleStoreFilesForIndexing(
  * @param {string} indexFormat
  * @param {string} fileReference
  * @param {API.ProcessFileForIndexingOptions} [options={}]
+ * @returns {Promise<API.MultihashDigest>}
  */
 export async function processFileForIndexing(
   fileStore,
@@ -77,12 +78,9 @@ export async function processFileForIndexing(
         ...options,
       }
     )
-
-    if (written) {
-      console.log(`File ${fileReference} indexed successfully.`)
-      // Return the containing multihash for further processing if needed
-      return written.containingMultihash
-    }
+    console.log(`File ${fileReference} indexed successfully.`)
+    // Return the containing multihash for further processing if needed
+    return written.containingMultihash
   } else {
     throw new Error(`Unsupported index format: ${indexFormat}`)
   }

--- a/packages/utils/src/index/unixfs.js
+++ b/packages/utils/src/index/unixfs.js
@@ -19,7 +19,7 @@ export const defaultSettings = UnixFS.configure({
  * @param {string} path
  * @param {PackAPI.IndexWriter[]} indexWriters
  * @param {API.CreateUnixFsFileLikeStreamOptions} [options]
- * @returns {Promise<{ containingMultihash: API.MultihashDigest} | undefined>}
+ * @returns {Promise<{ containingMultihash: API.MultihashDigest}>}
  */
 export async function writeUnixFsFileLinkIndex(
   blob,
@@ -28,7 +28,7 @@ export async function writeUnixFsFileLinkIndex(
   options
 ) {
   if (!indexWriters || !indexWriters.length) {
-    return
+    throw new Error('No index writers provided')
   }
   // Create a UnixFS file link stream
   const unixFsFileLinkStream = createUnixFsFileLinkStream(blob, options)

--- a/packages/utils/test/index/unixfs.test.js
+++ b/packages/utils/test/index/unixfs.test.js
@@ -538,8 +538,14 @@ describe(`unixfs index preparation`, () => {
     await packStore.put(location, bytes)
 
     // Write index for unixfs file links
-    const written = await writeUnixFsFileLinkIndex(blob, location, [])
-    assert.equal(written, undefined, 'index was written')
+    assert.rejects(
+      () => writeUnixFsFileLinkIndex(blob, location, []),
+      {
+        name: 'Error',
+        message: 'No index writers provided',
+      },
+      'should throw error when no index writers are provided'
+    )
   })
 })
 


### PR DESCRIPTION
also propagated return type to `processFileForIndexing`