### PR TITLE
fix: index pipeline supports unixfs storing dag

### DIFF
--- a/docs/src/content/docs/api/@hash-stream/index-pipeline/functions/processFileForIndexing.md
+++ b/docs/src/content/docs/api/@hash-stream/index-pipeline/functions/processFileForIndexing.md
@@ -5,9 +5,9 @@ prev: true
 title: "processFileForIndexing"
 ---
 
-> **processFileForIndexing**(`fileStore`, `indexWriters`, `indexFormat`, `fileReference`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`undefined` \| `MultihashDigest`\<`number`\>\>
+> **processFileForIndexing**(`fileStore`, `packStoreWriter`, `indexWriters`, `indexFormat`, `fileReference`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`MultihashDigest`\<`number`\>\>
 
-Defined in: [index.js:52](https://github.com/vasco-santos/hash-stream/blob/main/packages/index-pipeline/src/index.js#L52)
+Defined in: [index.js:54](https://github.com/vasco-santos/hash-stream/blob/main/packages/index-pipeline/src/index.js#L54)
 
 Scheduler consumer function where a file reference is fetched from the store,
 processed, and then written to the index store.
@@ -21,6 +21,7 @@ content to the index store using the provided index writer.
 | Parameter | Type |
 | ------ | ------ |
 | `fileStore` | `FileStore` |
+| `packStoreWriter` | `PackStoreWriter` |
 | `indexWriters` | `IndexWriter`[] |
 | `indexFormat` | `string` |
 | `fileReference` | `string` |
@@ -28,4 +29,4 @@ content to the index store using the provided index writer.
 
 ## Returns
 
-[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`undefined` \| `MultihashDigest`\<`number`\>\>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`MultihashDigest`\<`number`\>\>

--- a/docs/src/content/docs/api/@hash-stream/index/classes/SingleLevelIndexWriter.md
+++ b/docs/src/content/docs/api/@hash-stream/index/classes/SingleLevelIndexWriter.md
@@ -5,7 +5,7 @@ prev: true
 title: "SingleLevelIndexWriter"
 ---
 
-Defined in: [writer/single-level.js:17](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L17)
+Defined in: [writer/single-level.js:18](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L18)
 
 SingleLevelIndexWriter implements the Index Writer interface
 and provides methods to write blobs and packs.
@@ -18,7 +18,7 @@ and provides methods to write blobs and packs.
 
 > **new SingleLevelIndexWriter**(`store`): `SingleLevelIndexWriter`
 
-Defined in: [writer/single-level.js:21](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L21)
+Defined in: [writer/single-level.js:22](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L22)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Defined in: [writer/single-level.js:21](https://github.com/vasco-santos/hash-str
 
 > **addBlobs**(`blobIndexIterable`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`\>
 
-Defined in: [writer/single-level.js:31](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L31)
+Defined in: [writer/single-level.js:32](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L32)
 
 Indexes a given pack of blocks.
 
@@ -56,4 +56,4 @@ Indexes a given pack of blocks.
 
 > **store**: `IndexStore`
 
-Defined in: [writer/single-level.js:22](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L22)
+Defined in: [writer/single-level.js:23](https://github.com/vasco-santos/hash-stream/blob/main/packages/index/src/writer/single-level.js#L23)

--- a/packages/index-pipeline/package.json
+++ b/packages/index-pipeline/package.json
@@ -72,9 +72,11 @@
     "@aws-sdk/client-s3": "^3.817.0",
     "@aws-sdk/client-sqs": "^3.817.0",
     "@hash-stream/index": "workspace:^",
+    "@hash-stream/pack": "workspace:^",
     "@hash-stream/utils": "workspace:^",
     "@ipld/unixfs": "^3.0.0",
-    "@web3-storage/upload-client": "^17.1.4"
+    "@web3-storage/upload-client": "^17.1.4",
+    "multiformats": "^13.3.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250525.0",
@@ -96,7 +98,8 @@
     "p-retry": "^6.2.1",
     "sqs-consumer": "^12.0.0",
     "testcontainers": "^10.24.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "uint8arrays": "^5.1.0"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/index-pipeline/src/api.ts
+++ b/packages/index-pipeline/src/api.ts
@@ -10,7 +10,9 @@ export interface FileMetadata {
   size?: number
 }
 
-export interface FileStore {
+export interface FileStore extends FileStoreReader {}
+
+export interface FileStoreReader {
   /**
    * Lists all files available in the store.
    * Returns an iterable of file metadata or identifiers.
@@ -47,3 +49,5 @@ export interface QueuedIndexTask {
   fileReference: string
   options?: IndexSchedulerAddOptions
 }
+
+export type Path = string

--- a/packages/index-pipeline/src/index.js
+++ b/packages/index-pipeline/src/index.js
@@ -44,6 +44,7 @@ export async function* scheduleStoreFilesForIndexing(
  * content to the index store using the provided index writer.
  *
  * @param {API.FileStore} fileStore
+ * @param {import('@hash-stream/pack/types').PackStoreWriter} packStoreWriter
  * @param {import('@hash-stream/index/types').IndexWriter[]} indexWriters
  * @param {string} indexFormat
  * @param {string} fileReference
@@ -52,6 +53,7 @@ export async function* scheduleStoreFilesForIndexing(
  */
 export async function processFileForIndexing(
   fileStore,
+  packStoreWriter,
   indexWriters,
   indexFormat,
   fileReference,
@@ -70,6 +72,7 @@ export async function processFileForIndexing(
       blob,
       fileReference,
       indexWriters,
+      packStoreWriter,
       {
         settings: {
           ...defaultSettings,

--- a/packages/index-pipeline/test/index.node.test.js
+++ b/packages/index-pipeline/test/index.node.test.js
@@ -1,6 +1,7 @@
 import { runIndexPipelineTests } from './index.js'
 
 import { MemoryIndexStore } from '@hash-stream/index/store/memory'
+import { MemoryPackStore } from '@hash-stream/pack/store/memory'
 import { MultipleLevelIndexWriter, IndexReader } from '@hash-stream/index'
 
 import {
@@ -19,6 +20,12 @@ describe('indexPipeline combinations', () => {
     {
       name: 'S3Like + SQSLike',
       getFileStore: getS3LikeFileStore,
+      createPackStoreWriter: () =>
+        Promise.resolve(
+          Object.assign(new MemoryPackStore(), {
+            destroy: () => {},
+          })
+        ),
       getIndexScheduler: getSQSLikeScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
@@ -37,6 +44,12 @@ describe('indexPipeline combinations', () => {
     {
       name: 'S3Like + Memory',
       getFileStore: getS3LikeFileStore,
+      createPackStoreWriter: () =>
+        Promise.resolve(
+          Object.assign(new MemoryPackStore(), {
+            destroy: () => {},
+          })
+        ),
       getIndexScheduler: getMemoryScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
@@ -55,6 +68,12 @@ describe('indexPipeline combinations', () => {
     {
       name: 'Cloudflare Worker Bucket + SQSLike',
       getFileStore: getCloudflareWorkerBucketStore,
+      createPackStoreWriter: () =>
+        Promise.resolve(
+          Object.assign(new MemoryPackStore(), {
+            destroy: () => {},
+          })
+        ),
       getIndexScheduler: getSQSLikeScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
@@ -73,6 +92,12 @@ describe('indexPipeline combinations', () => {
     {
       name: 'Cloudflare Worker Bucket + Memory',
       getFileStore: getCloudflareWorkerBucketStore,
+      createPackStoreWriter: () =>
+        Promise.resolve(
+          Object.assign(new MemoryPackStore(), {
+            destroy: () => {},
+          })
+        ),
       getIndexScheduler: getMemoryScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
@@ -91,6 +116,12 @@ describe('indexPipeline combinations', () => {
     {
       name: 'FS + SQSLike',
       getFileStore: getFsStore,
+      createPackStoreWriter: () =>
+        Promise.resolve(
+          Object.assign(new MemoryPackStore(), {
+            destroy: () => {},
+          })
+        ),
       getIndexScheduler: getSQSLikeScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
@@ -109,6 +140,12 @@ describe('indexPipeline combinations', () => {
     {
       name: 'FS + Memory',
       getFileStore: getFsStore,
+      createPackStoreWriter: () =>
+        Promise.resolve(
+          Object.assign(new MemoryPackStore(), {
+            destroy: () => {},
+          })
+        ),
       getIndexScheduler: getMemoryScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
@@ -129,6 +166,7 @@ describe('indexPipeline combinations', () => {
       name,
       getFileStore,
       getIndexScheduler,
+      createPackStoreWriter,
       createIndexWriters,
       createIndexReader,
     }) => {
@@ -137,7 +175,8 @@ describe('indexPipeline combinations', () => {
         getFileStore,
         getIndexScheduler,
         createIndexWriters,
-        createIndexReader
+        createIndexReader,
+        createPackStoreWriter
       )
     }
   )

--- a/packages/index-pipeline/test/index.test.js
+++ b/packages/index-pipeline/test/index.test.js
@@ -1,3 +1,4 @@
+import { MemoryPackStore } from '@hash-stream/pack/store/memory'
 import { MemoryIndexStore } from '@hash-stream/index/store/memory'
 import { MultipleLevelIndexWriter, IndexReader } from '@hash-stream/index'
 
@@ -14,6 +15,12 @@ describe('indexPipeline combinations', () => {
     {
       name: 'MemoryFileStore + MemoryIndexScheduler',
       getFileStore: getMemoryStore,
+      createPackStoreWriter: () =>
+        Promise.resolve(
+          Object.assign(new MemoryPackStore(), {
+            destroy: () => {},
+          })
+        ),
       /**
        * @returns {Promise<API.IndexScheduler & { destroy(): void, drain(): AsyncGenerator<API.QueuedIndexTask> }>}
        */
@@ -38,13 +45,15 @@ describe('indexPipeline combinations', () => {
       getIndexScheduler,
       createIndexWriters,
       createIndexReader,
+      createPackStoreWriter,
     }) => {
       runIndexPipelineTests(
         name,
         getFileStore,
         getIndexScheduler,
         createIndexWriters,
-        createIndexReader
+        createIndexReader,
+        createPackStoreWriter
       )
     }
   )

--- a/packages/index/src/writer/single-level.js
+++ b/packages/index/src/writer/single-level.js
@@ -1,6 +1,7 @@
 import * as API from '../api.js'
 
 import { base58btc } from 'multiformats/bases/base58'
+import { equals } from 'uint8arrays'
 
 import { createFromBlob, createFromPack } from '../record.js'
 
@@ -56,8 +57,12 @@ export class SingleLevelIndexWriter {
       const blob = createFromBlob(multihash, location, offset, length)
       yield blob
 
-      // If the location is not a string, we can create a Pack Index record
-      if (typeof location !== 'string') {
+      // If the location is not a string and not equal to the multihash itself,
+      // we can create a Pack Index record
+      if (
+        typeof location !== 'string' &&
+        !equals(multihash.bytes, location.bytes)
+      ) {
         // Create/Update Pack Index record
         const encodedLocation = base58btc.encode(location.bytes)
         packs.set(encodedLocation, location)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -30,11 +30,13 @@ const blob = new Blob(['hello world'])
 const indexWriters = [
   /* your Hashstream IndexWriter instances */
 ]
+const packStore = // your Hashstream Pack store of choice instance
 
 const { containingMultihash } = await writeUnixFsFileLinkIndex(
   blob,
   '/file.txt',
   indexWriters,
+  packStore,
   {
     notIndexContaining: false,
     settings: {
@@ -50,6 +52,7 @@ const { containingMultihash } = await writeUnixFsFileLinkIndex(
 - `blob` (`BlobLike`) – The file blob to be split into UnixFS chunks.
 - `path` (`string`) – Virtual path to associate with the entries in the index.
 - `indexWriters` (`IndexWriter[]`) – Array of writers that receive streamable index entries.
+- `PackStore` - Pack Store where UnixFS block with root of DAG can be stored.
 - `options` (optional) (`CreateUnixFsFileLikeStreamOptions`):
   - `notIndexContaining` (`boolean`) – If `true`, skips indexing the containing multihash in an hierarchy.
   - `settings` (`Partial<UnixFSEncodeSettings>`) – Optional settings passed to the UnixFS writer.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -65,6 +65,7 @@
     "@vascosantos/unixfs": "^3.0.3",
     "ipfs-core-utils": "^0.18.1",
     "multiformats": "^13.3.2",
+    "p-defer": "^4.0.1",
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/utils/src/index/api.ts
+++ b/packages/utils/src/index/api.ts
@@ -1,9 +1,15 @@
 import { MultihashDigest } from 'multiformats'
 import { UnixFSEncoderSettingsOptions } from '@web3-storage/upload-client/types'
+import { FileLink, Block } from '@vascosantos/unixfs'
 
 export interface CreateUnixFsFileLikeStreamOptions
   extends UnixFSEncoderSettingsOptions {
   notIndexContaining?: boolean
 }
 
-export type { MultihashDigest }
+export interface UnixFsStreams {
+  unixFsFileLinkReadable: ReadableStream<FileLink>
+  unixFsReadable: ReadableStream<Block>
+}
+
+export type { MultihashDigest, FileLink, Block }

--- a/packages/utils/src/index/utils.js
+++ b/packages/utils/src/index/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Reads all chunks from a ReadableStream and returns them as an array.
+ *
+ * @template T
+ * @param {ReadableStream<T>} stream
+ * @returns {Promise<T[]>}
+ */
+export async function readAll(stream) {
+  const reader = stream.getReader()
+  const chunks = []
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  return chunks
+}
+
+/**
+ * Reads all chunks from a ReadableStream and returns the last.
+ *
+ * @template T
+ * @param {ReadableStream<T>} stream
+ * @returns {Promise<T | undefined>}
+ */
+export async function readLast(stream) {
+  const reader = stream.getReader()
+  let chunk
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    chunk = value
+  }
+  return chunk
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       '@hash-stream/index':
         specifier: workspace:^
         version: link:../index
+      '@hash-stream/pack':
+        specifier: workspace:^
+        version: link:../pack
       '@hash-stream/utils':
         specifier: workspace:^
         version: link:../utils
@@ -288,6 +291,9 @@ importers:
       '@web3-storage/upload-client':
         specifier: ^17.1.4
         version: 17.1.4(encoding@0.1.13)
+      multiformats:
+        specifier: ^13.3.2
+        version: 13.3.4
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250525.0
@@ -349,6 +355,9 @@ importers:
       typescript:
         specifier: ^5.8.2
         version: 5.8.3
+      uint8arrays:
+        specifier: ^5.1.0
+        version: 5.1.0
 
   packages/pack:
     dependencies:
@@ -516,6 +525,9 @@ importers:
       multiformats:
         specifier: ^13.3.2
         version: 13.3.4
+      p-defer:
+        specifier: ^4.0.1
+        version: 4.0.1
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.0


### PR DESCRIPTION
Supports storing unixfs data to be able to export it back from a CAR file 