### PR TITLE
feat: unixfs pack reader

### DIFF
--- a/docs/src/content/docs/api/@hash-stream/pack/classes/PackReader.md
+++ b/docs/src/content/docs/api/@hash-stream/pack/classes/PackReader.md
@@ -15,7 +15,7 @@ PackReader is responsible for reading packs from the store.
 
 ### Constructor
 
-> **new PackReader**(`storeReader`): `PackReader`
+> **new PackReader**(`storeStreamer`): `PackReader`
 
 Defined in: [reader.js:13](https://github.com/vasco-santos/hash-stream/blob/main/packages/pack/src/reader.js#L13)
 
@@ -23,7 +23,7 @@ Defined in: [reader.js:13](https://github.com/vasco-santos/hash-stream/blob/main
 
 | Parameter | Type |
 | ------ | ------ |
-| `storeReader` | `PackStoreReader` |
+| `storeStreamer` | `PackStoreStreamer` |
 
 #### Returns
 
@@ -50,8 +50,8 @@ Defined in: [reader.js:22](https://github.com/vasco-santos/hash-stream/blob/main
 
 ## Properties
 
-### storeReader
+### storeStreamer
 
-> **storeReader**: `PackStoreReader`
+> **storeStreamer**: `PackStoreStreamer`
 
 Defined in: [reader.js:14](https://github.com/vasco-santos/hash-stream/blob/main/packages/pack/src/reader.js#L14)

--- a/packages/index-pipeline/package.json
+++ b/packages/index-pipeline/package.json
@@ -81,6 +81,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250525.0",
     "@hash-stream/eslint-config": "workspace:^",
+    "@hash-stream/streamer": "workspace:^",
     "@storacha/one-webcrypto": "^1.0.1",
     "@types/assert": "^1.5.11",
     "@types/mocha": "^10.0.10",

--- a/packages/index-pipeline/test/file-store/constructs.browser.js
+++ b/packages/index-pipeline/test/file-store/constructs.browser.js
@@ -1,3 +1,5 @@
+import { sha256 } from 'multiformats/hashes/sha2'
+
 import { MemoryFileStore } from '../../src/file-store/memory.js'
 
 export const getMemoryStore = async () => {
@@ -10,6 +12,46 @@ export const getMemoryStore = async () => {
      */
     async put(key, bytes) {
       files.set(key, bytes)
+    },
+    /**
+     * Retrieves bytes of a pack file by its multihash digest and streams it in specified ranges.
+     *
+     * @param {import('@hash-stream/pack/types').MultihashDigest | import('@hash-stream/pack/types').Path} target - The Multihash digest of the pack or its path.
+     * @param {Array<{ offset?: number, length?: number, multihash: import('@hash-stream/pack/types').MultihashDigest }>} [ranges]
+     * @returns {AsyncIterable<import('@hash-stream/pack/types').VerifiableEntry>}
+     */
+    async *stream(target, ranges = []) {
+      if (typeof target !== 'string') {
+        throw new Error('only string paths are supported for S3LikeFileStore')
+      }
+
+      const bytes = files.get(target)
+      /* c8 ignore next 1 */
+      if (!bytes) return
+
+      if (ranges.length === 0) {
+        let multihash
+        if (typeof target === 'string') {
+          // If target is a path, we need to calculate the hash
+          multihash = await sha256.digest(bytes)
+        }
+        // If target is a multihash, we can use it directly
+        else {
+          multihash = target
+        }
+        yield { multihash, bytes }
+        return
+      }
+
+      for (const { multihash, offset, length } of ranges) {
+        const computedOffset = offset ?? 0
+        /* c8 ignore next 1 */
+        const slice = bytes.slice(
+          computedOffset,
+          length ? computedOffset + length : undefined
+        )
+        yield { multihash, bytes: slice }
+      }
     },
   })
 }

--- a/packages/index-pipeline/test/file-store/constructs.js
+++ b/packages/index-pipeline/test/file-store/constructs.js
@@ -2,11 +2,13 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
+import { sha256 } from 'multiformats/hashes/sha2'
+
 import { FSFileStore } from '../../src/file-store/fs.js'
 import { S3LikeFileStore } from '../../src/file-store/s3-like.js'
 import { CloudflareWorkerBucketFileStore } from '../../src/file-store/cf-worker-bucket.js'
 
-import { PutObjectCommand } from '@aws-sdk/client-s3'
+import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3'
 
 import {
   createS3Like,
@@ -33,6 +35,77 @@ export const getS3LikeFileStore = async () => {
         })
       )
     },
+    /**
+     * Retrieves bytes of a pack file from S3 by its multihash digest and streams it in specified ranges.
+     *
+     * @param {import('@hash-stream/pack/types').MultihashDigest | import('@hash-stream/pack/types').Path} target - The Multihash digest of the pack or its path.
+     * @param {Array<{ offset?: number, length?: number, multihash: import('@hash-stream/pack/types').MultihashDigest }>} [ranges]
+     * @returns {AsyncIterable<import('@hash-stream/pack/types').VerifiableEntry>}
+     */
+    async *stream(target, ranges = []) {
+      if (typeof target !== 'string') {
+        throw new Error('only string paths are supported for S3LikeFileStore')
+      }
+
+      // If no ranges, stream the entire file
+      if (ranges.length === 0) {
+        try {
+          const { Body } = await client.send(
+            new GetObjectCommand({
+              Bucket: bucketName,
+              Key: target,
+            })
+          )
+          /* c8 ignore next 1 */
+          if (!Body) return
+
+          const bytes = new Uint8Array(await Body.transformToByteArray())
+          let multihash
+          if (typeof target === 'string') {
+            // If target is a path, we need to calculate the hash
+            multihash = await sha256.digest(bytes)
+          }
+          // If target is a multihash, we can use it directly
+          else {
+            multihash = target
+          }
+          yield { multihash, bytes }
+        } catch (/** @type {any} */ err) {
+          /* c8 ignore next 1 */
+          if (err.name !== 'NoSuchKey') throw err
+        }
+        return
+      }
+
+      // Handle ranged reads
+      for (const { multihash, offset, length } of ranges) {
+        try {
+          const computedOffset = offset ?? 0
+          /* c8 ignore next 11 */
+          const rangeHeader = `bytes=${computedOffset}-${
+            length ? computedOffset + length - 1 : ''
+          }`
+          const { Body } = await client.send(
+            new GetObjectCommand({
+              Bucket: bucketName,
+              Key: target,
+              Range: rangeHeader,
+              // Needed because range GET won't be the entire file
+              // @ts-expect-error
+              ChecksumMode: 'DISABLED',
+            })
+          )
+          /* c8 ignore next 1 */
+          if (!Body) continue
+
+          const buffer = new Uint8Array(await Body.transformToByteArray())
+          yield { multihash, bytes: buffer }
+        } catch (/** @type {any} */ err) {
+          /* c8 ignore next 1 */
+          if (err.name !== 'NoSuchKey') throw err
+        }
+      }
+    },
   })
 }
 
@@ -49,6 +122,58 @@ export const getCloudflareWorkerBucketStore = async () => {
      */
     async put(key, bytes) {
       await bucket.put(key, bytes)
+    },
+    /**
+     * Retrieves bytes of a pack file from R2 by its multihash digest or path and streams it in specified ranges.
+     *
+     * @param {import('@hash-stream/pack/types').MultihashDigest | import('@hash-stream/pack/types').Path} target - The Multihash digest of the pack or its path.
+     * @param {Array<{ offset?: number, length?: number, multihash: import('@hash-stream/pack/types').MultihashDigest }>} [ranges]
+     * @returns {AsyncIterable<import('@hash-stream/pack/types').VerifiableEntry>}
+     */
+    async *stream(target, ranges = []) {
+      if (typeof target !== 'string') {
+        throw new Error('only string paths are supported for S3LikeFileStore')
+      }
+
+      // If no ranges, stream the entire file
+      if (ranges.length === 0) {
+        const r2ObjectBody = await bucket.get(target)
+        if (!r2ObjectBody) return
+
+        const buffer = await r2ObjectBody.arrayBuffer()
+        const bytes = new Uint8Array(buffer)
+        let multihash
+        if (typeof target === 'string') {
+          // If target is a path, we need to calculate the hash
+          multihash = await sha256.digest(bytes)
+        }
+        // If target is a multihash, we can use it directly
+        else {
+          multihash = target
+        }
+        yield { multihash, bytes }
+        return
+      }
+
+      // Handle ranged reads
+      for (const { multihash, offset, length } of ranges) {
+        try {
+          const r2ObjectBody = await bucket.get(target, {
+            range: {
+              offset,
+              length: length ?? 0,
+            },
+          })
+          if (!r2ObjectBody) continue
+
+          const buffer = new Uint8Array(await r2ObjectBody.arrayBuffer())
+          yield { multihash, bytes: buffer }
+          /* c8 ignore next 4 */
+        } catch (err) {
+          // Handle error silently
+          continue
+        }
+      }
     },
   })
 }
@@ -72,6 +197,99 @@ export const getFsStore = async () => {
       fs.mkdirSync(dirPath, { recursive: true })
       fs.writeFileSync(filePath, bytes)
     },
+    /**
+     * Retrieves bytes of a pack file by its multihash digest and streams it in specified ranges.
+     *
+     * @param {import('@hash-stream/pack/types').MultihashDigest | import('@hash-stream/pack/types').Path} target - The Multihash digest of the pack or its path.
+     * @param {Array<{ offset?: number, length?: number, multihash: import('@hash-stream/pack/types').MultihashDigest }>} [ranges]
+     * @returns {AsyncIterable<import('@hash-stream/pack/types').VerifiableEntry>}
+     */
+    async *stream(target, ranges = []) {
+      if (typeof target !== 'string') {
+        throw new Error('only string paths are supported for S3LikeFileStore')
+      }
+
+      const filePath = path.join(tempDir, target)
+
+      // Check if ranges are provided
+      if (ranges.length === 0) {
+        // If no ranges, stream the entire file
+        try {
+          const fileBuffer = await fs.promises.readFile(filePath)
+          let multihash
+          if (typeof target === 'string') {
+            // If target is a path, we need to calculate the hash
+            multihash = await sha256.digest(fileBuffer)
+          }
+          // If target is a multihash, we can use it directly
+          else {
+            multihash = target
+          }
+          yield { multihash, bytes: fileBuffer }
+        } catch (/** @type {any} */ err) {
+          /* c8 ignore next 4 */
+          if (err.code !== 'ENOENT') {
+            // If the file doesn't exist, return null, otherwise throw
+            throw err
+          }
+        }
+        return
+      }
+      // For each range, create a stream that reads the file chunk and buffers it
+      for (const { multihash, offset, length } of ranges) {
+        try {
+          // @ts-expect-error we should be able to use the length property
+          const buffer = await _bufferStream(filePath, offset, length)
+          yield { multihash, bytes: buffer }
+        } catch (/** @type {any} */ err) {
+          /* c8 ignore next 4 */
+          if (err.code !== 'ENOENT') {
+            // If the file doesn't exist, return null, otherwise throw
+            throw err
+          }
+        }
+      }
+    },
   })
   return Promise.resolve(fileStoreImplementation)
+}
+
+/**
+ * Buffers the content of the file between the provided offset and length.
+ *
+ * @param {string} filePath - Path to the file.
+ * @param {number} offset - Starting offset to read from.
+ * @param {number} length - Length of the range to read.
+ * @returns {Promise<Uint8Array>} - The buffered content of the range.
+ */
+async function _bufferStream(filePath, offset, length) {
+  return new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath, {
+      start: offset,
+      end: offset + length - 1,
+    })
+
+    /** @type {Uint8Array[]} */
+    const chunks = []
+    let totalSize = 0
+
+    stream.on('data', (chunk) => {
+      // @ts-expect-error chunk is a Buffer
+      const chunkArray = new Uint8Array(chunk) // Convert to Uint8Array
+      chunks.push(chunkArray)
+      totalSize += chunkArray.length
+    })
+
+    stream.on('end', () => {
+      const result = new Uint8Array(totalSize)
+      let offset = 0
+      for (const chunk of chunks) {
+        result.set(chunk, offset)
+        offset += chunk.length
+      }
+      resolve(result)
+    })
+
+    stream.on('error', reject)
+  })
 }

--- a/packages/index-pipeline/test/index-scheduler/constructs.browser.js
+++ b/packages/index-pipeline/test/index-scheduler/constructs.browser.js
@@ -4,7 +4,7 @@ import * as API from '../../src/api.js'
 
 import { MemoryIndexScheduler } from '../../src/index-scheduler/memory.js'
 
-export const getMemoryScheduler = async () => {
+export const createMemoryScheduler = async () => {
   /** @type {API.QueuedIndexTask[]} */
   const queue = []
   const scheduler = new MemoryIndexScheduler(queue)

--- a/packages/index-pipeline/test/index-scheduler/constructs.js
+++ b/packages/index-pipeline/test/index-scheduler/constructs.js
@@ -12,7 +12,7 @@ import { createQueue, createSQS } from '../helpers/resources.js'
 /**
  * @param {number} [messageTarget]
  */
-export const getSQSLikeScheduler = async (messageTarget = 0) => {
+export const createSQSLikeScheduler = async (messageTarget = 0) => {
   const { client: sqsClient } = await createSQS()
   const queueUrl = await createQueue(sqsClient)
   /** @type {API.QueuedIndexTask[]} */

--- a/packages/index-pipeline/test/index-scheduler/index.test.js
+++ b/packages/index-pipeline/test/index-scheduler/index.test.js
@@ -1,12 +1,12 @@
 import { runIndexSchedulerTests } from './index.js'
-import { getMemoryScheduler } from './constructs.browser.js'
+import { createMemoryScheduler } from './constructs.browser.js'
 
 describe('IndexScheduler implementations', () => {
   // eslint-disable-next-line no-extra-semi
   ;[
     {
       name: 'Memory',
-      getIndexScheduler: getMemoryScheduler,
+      getIndexScheduler: createMemoryScheduler,
     },
   ].forEach(({ name, getIndexScheduler }) => {
     runIndexSchedulerTests(name, () => getIndexScheduler())

--- a/packages/index-pipeline/test/index.node.test.js
+++ b/packages/index-pipeline/test/index.node.test.js
@@ -9,24 +9,27 @@ import {
   getCloudflareWorkerBucketStore,
   getFsStore,
 } from './file-store/constructs.js'
-import { getSQSLikeScheduler } from './index-scheduler/constructs.js'
-import { getMemoryScheduler } from './index-scheduler/constructs.browser.js'
+import { createSQSLikeScheduler } from './index-scheduler/constructs.js'
+import { createMemoryScheduler } from './index-scheduler/constructs.browser.js'
 
 describe('indexPipeline combinations', () => {
   let indexStore = new MemoryIndexStore()
+  let packStore = new MemoryPackStore()
 
   // eslint-disable-next-line no-extra-semi
   ;[
     {
       name: 'S3Like + SQSLike',
-      getFileStore: getS3LikeFileStore,
+      createFileStore: getS3LikeFileStore,
       createPackStoreWriter: () =>
         Promise.resolve(
-          Object.assign(new MemoryPackStore(), {
-            destroy: () => {},
+          Object.assign(packStore, {
+            destroy: () => {
+              packStore = new MemoryPackStore()
+            },
           })
         ),
-      getIndexScheduler: getSQSLikeScheduler,
+      createIndexScheduler: createSQSLikeScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
        */
@@ -43,14 +46,16 @@ describe('indexPipeline combinations', () => {
     },
     {
       name: 'S3Like + Memory',
-      getFileStore: getS3LikeFileStore,
+      createFileStore: getS3LikeFileStore,
       createPackStoreWriter: () =>
         Promise.resolve(
-          Object.assign(new MemoryPackStore(), {
-            destroy: () => {},
+          Object.assign(packStore, {
+            destroy: () => {
+              packStore = new MemoryPackStore()
+            },
           })
         ),
-      getIndexScheduler: getMemoryScheduler,
+      createIndexScheduler: createMemoryScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
        */
@@ -67,14 +72,16 @@ describe('indexPipeline combinations', () => {
     },
     {
       name: 'Cloudflare Worker Bucket + SQSLike',
-      getFileStore: getCloudflareWorkerBucketStore,
+      createFileStore: getCloudflareWorkerBucketStore,
       createPackStoreWriter: () =>
         Promise.resolve(
-          Object.assign(new MemoryPackStore(), {
-            destroy: () => {},
+          Object.assign(packStore, {
+            destroy: () => {
+              packStore = new MemoryPackStore()
+            },
           })
         ),
-      getIndexScheduler: getSQSLikeScheduler,
+      createIndexScheduler: createSQSLikeScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
        */
@@ -91,14 +98,16 @@ describe('indexPipeline combinations', () => {
     },
     {
       name: 'Cloudflare Worker Bucket + Memory',
-      getFileStore: getCloudflareWorkerBucketStore,
+      createFileStore: getCloudflareWorkerBucketStore,
       createPackStoreWriter: () =>
         Promise.resolve(
-          Object.assign(new MemoryPackStore(), {
-            destroy: () => {},
+          Object.assign(packStore, {
+            destroy: () => {
+              packStore = new MemoryPackStore()
+            },
           })
         ),
-      getIndexScheduler: getMemoryScheduler,
+      createIndexScheduler: createMemoryScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
        */
@@ -115,14 +124,16 @@ describe('indexPipeline combinations', () => {
     },
     {
       name: 'FS + SQSLike',
-      getFileStore: getFsStore,
+      createFileStore: getFsStore,
       createPackStoreWriter: () =>
         Promise.resolve(
-          Object.assign(new MemoryPackStore(), {
-            destroy: () => {},
+          Object.assign(packStore, {
+            destroy: () => {
+              packStore = new MemoryPackStore()
+            },
           })
         ),
-      getIndexScheduler: getSQSLikeScheduler,
+      createIndexScheduler: createSQSLikeScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
        */
@@ -139,14 +150,16 @@ describe('indexPipeline combinations', () => {
     },
     {
       name: 'FS + Memory',
-      getFileStore: getFsStore,
+      createFileStore: getFsStore,
       createPackStoreWriter: () =>
         Promise.resolve(
-          Object.assign(new MemoryPackStore(), {
-            destroy: () => {},
+          Object.assign(packStore, {
+            destroy: () => {
+              packStore = new MemoryPackStore()
+            },
           })
         ),
-      getIndexScheduler: getMemoryScheduler,
+      createIndexScheduler: createMemoryScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
        */
@@ -164,16 +177,16 @@ describe('indexPipeline combinations', () => {
   ].forEach(
     ({
       name,
-      getFileStore,
-      getIndexScheduler,
+      createFileStore,
+      createIndexScheduler,
       createPackStoreWriter,
       createIndexWriters,
       createIndexReader,
     }) => {
       runIndexPipelineTests(
         name,
-        getFileStore,
-        getIndexScheduler,
+        createFileStore,
+        createIndexScheduler,
         createIndexWriters,
         createIndexReader,
         createPackStoreWriter

--- a/packages/index-pipeline/test/index.test.js
+++ b/packages/index-pipeline/test/index.test.js
@@ -5,7 +5,7 @@ import { MultipleLevelIndexWriter, IndexReader } from '@hash-stream/index'
 import { runIndexPipelineTests } from './index.js'
 
 import { getMemoryStore } from './file-store/constructs.browser.js'
-import { getMemoryScheduler } from './index-scheduler/constructs.browser.js'
+import { createMemoryScheduler } from './index-scheduler/constructs.browser.js'
 
 describe('indexPipeline combinations', () => {
   let indexStore = new MemoryIndexStore()
@@ -24,7 +24,7 @@ describe('indexPipeline combinations', () => {
       /**
        * @returns {Promise<API.IndexScheduler & { destroy(): void, drain(): AsyncGenerator<API.QueuedIndexTask> }>}
        */
-      getIndexScheduler: getMemoryScheduler,
+      getIndexScheduler: createMemoryScheduler,
       /**
        * @returns {Promise<import('@hash-stream/index/types').IndexWriter[]>}
        */

--- a/packages/pack/package.json
+++ b/packages/pack/package.json
@@ -19,7 +19,7 @@
     "dev": "tsc --build --watch",
     "test": "npm run test:all",
     "test:all": "run-s test:browser test:node",
-    "test:node": "hundreds -r html -r text mocha 'test/**/!(*.browser).test.js' -n experimental-vm-modules -n no-warnings --timeout=30s",
+    "test:node": "hundreds -r html -r text mocha 'test/**/!(*.browser).test.js' -n experimental-vm-modules -n no-warnings --timeout=90s",
     "test:browser": "playwright-test --runner mocha 'test/**/!(*.node).test.js'",
     "rc": "npm version prerelease --preid rc"
   },

--- a/packages/pack/src/api.ts
+++ b/packages/pack/src/api.ts
@@ -19,7 +19,7 @@ export type {
 }
 
 export interface PackReader {
-  storeReader: PackStoreReader
+  storeStreamer: PackStoreStreamer
 
   /**
    * Stream data from a Pack, optionally requesting specific byte ranges.
@@ -91,7 +91,7 @@ export interface PackStoreWriter {
   put(target: MultihashDigest | Path, data: Uint8Array): Promise<void>
 }
 
-export interface PackStoreReader {
+export interface PackStoreReader extends PackStoreStreamer {
   /**
    * Retrieves bytes of a pack file by its multihash digest or Path.
    *
@@ -99,7 +99,9 @@ export interface PackStoreReader {
    * @returns A promise that resolves with the pack file data or null if not found.
    */
   get(target: MultihashDigest | Path): Promise<Uint8Array | null>
+}
 
+export interface PackStoreStreamer {
   stream(
     target: MultihashDigest | Path,
     ranges?: Array<{

--- a/packages/pack/src/reader.js
+++ b/packages/pack/src/reader.js
@@ -8,10 +8,10 @@ import * as API from './api.js'
 export class PackReader {
   /**
    *
-   * @param {API.PackStoreReader} storeReader
+   * @param {API.PackStoreStreamer} storeStreamer
    */
-  constructor(storeReader) {
-    this.storeReader = storeReader
+  constructor(storeStreamer) {
+    this.storeStreamer = storeStreamer
   }
 
   /**
@@ -20,6 +20,6 @@ export class PackReader {
    * @returns {AsyncIterable<API.VerifiableEntry>}
    */
   stream(target, ranges) {
-    return this.storeReader.stream(target, ranges)
+    return this.storeStreamer.stream(target, ranges)
   }
 }

--- a/packages/streamer/test/hash-streamer.js
+++ b/packages/streamer/test/hash-streamer.js
@@ -218,9 +218,7 @@ export function runHashStreamTests(
       assert(equals(carMultihash.bytes, packMultihash.bytes))
 
       // Verify the created CAR file agains the one stored in the PackStore
-      const carBytesFromPackStore = await packReader.storeReader.get(
-        packMultihash
-      )
+      const carBytesFromPackStore = await packStore.get(packMultihash)
       assert(carBytesFromPackStore)
       assert(equals(carBytesFromPackStore, writtenCarBytes))
     })

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -100,6 +100,33 @@ while (true) {
 **Returns:** `ReadableStream<FileLink>`  
 A stream of metadata entries (`FileLink`) describing the chunks and layout of the encoded UnixFS file.
 
+### `index/unixfs-pack-reader`
+
+#### `UnixFsPackReader`
+
+Provides a way to stream file data from multiple pack stores depending on the input type (multihash digest or path). This is useful for keeping original raw files in a separate store and UnixFS Dag files in another store.
+
+```ts
+import { UnixFsPackReader } from '@hash-stream/utils/index/unixfs-pack-reader'
+
+const reader = new UnixFsPackReader(multihashPackStore, pathPackStore)
+
+for await (const entry of reader.stream(someTarget)) {
+  console.log(entry) // VerifiableEntry
+}
+```
+
+**Constructor:**
+- `new UnixFsPackReader(packStoreStreamer, pathStoreStreamer)`
+  - `packStoreStreamer` (`PackStoreStreamer`) – Used for multihash-based lookups
+  - `pathStoreStreamer` (`PackStoreStreamer`) – Used for path-based lookups
+
+**Method:**
+- `stream(target, ranges?)`
+  - `target`: `MultihashDigest | Path` – The target to retrieve
+  - `ranges`: Optional array of `{ offset, length?, multihash }` range descriptors
+  - **Returns:** `AsyncIterable<VerifiableEntry>`
+
 ### `trustless-ipfs-gateway`
 
 #### `streamer.asRawUint8Array`

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -29,6 +29,7 @@
     "./trustless-ipfs-gateway/types": "./dist/src/trustless-ipfs-gateway/api.js",
     "./index": "./dist/src/index/index.js",
     "./index/unixfs": "./dist/src/index/unixfs.js",
+    "./index/unixfs-pack-reader": "./dist/src/index/unixfs-pack-reader.js",
     "./index/types": "./dist/src/index/api.js"
   },
   "typesVersions": {
@@ -47,6 +48,9 @@
       ],
       "index/unixfs": [
         "dist/src/index/unixfs.d.ts"
+      ],
+      "index/unixfs-pack-reader": [
+        "dist/src/index/unixfs-pack-reader.d.ts"
       ],
       "index/types": [
         "dist/src/index/api.d.ts"

--- a/packages/utils/src/index/unixfs-pack-reader.js
+++ b/packages/utils/src/index/unixfs-pack-reader.js
@@ -1,0 +1,34 @@
+import * as API from '@hash-stream/pack/types'
+
+/**
+ * PackReader is responsible for reading packs from the store.
+ * With the UnixFSPackReader, we can read both multihash digests and paths from different stores
+ * behind the same reader. This is useful for keeping original raw files in a separate store and
+ * UnixFS Dag files in another store.
+ *
+ * @implements {API.PackReader}
+ */
+export class UnixFsPackReader {
+  /**
+   * @param {API.PackStoreStreamer} packStoreStreamer
+   * @param {API.PackStoreStreamer} pathStoreStreamer
+   */
+  constructor(packStoreStreamer, pathStoreStreamer) {
+    this.storeStreamer = packStoreStreamer
+    this.pathStoreStreamer = pathStoreStreamer
+  }
+
+  /**
+   * @param {API.MultihashDigest | API.Path} target
+   * @param {Array<{ offset: number, length?: number, multihash: API.MultihashDigest }>} [ranges]
+   * @returns {AsyncIterable<API.VerifiableEntry>}
+   */
+  stream(target, ranges) {
+    if (typeof target === 'string') {
+      // If the target is a path, we need to resolve it from the path
+      return this.pathStoreStreamer.stream(target, ranges)
+    }
+    // If the target is a multihash digest, we can stream directly from the pack store
+    return this.storeStreamer.stream(target, ranges)
+  }
+}

--- a/packages/utils/test/trustless-ipfs-gateway/http.test.js
+++ b/packages/utils/test/trustless-ipfs-gateway/http.test.js
@@ -544,9 +544,7 @@ describe(`trustless ipfs gateway http utils`, () => {
     assert(equals(carMultihash.bytes, packMultihash.bytes))
 
     // Verify the read CAR file agains the one stored in the PackStore
-    const carBytesFromPackStore = await packReader.storeReader.get(
-      packMultihash
-    )
+    const carBytesFromPackStore = await packStore.get(packMultihash)
     assert(carBytesFromPackStore)
     assert(equals(carBytesFromPackStore, bodyBytes))
   })

--- a/packages/utils/test/trustless-ipfs-gateway/streamer.test.js
+++ b/packages/utils/test/trustless-ipfs-gateway/streamer.test.js
@@ -143,9 +143,7 @@ describe(`trustless ipfs gateway streamer utils`, () => {
     assert(equals(carMultihash.bytes, packMultihash.bytes))
 
     // Verify the created CAR file agains the one stored in the PackStore
-    const carBytesFromPackStore = await packReader.storeReader.get(
-      packMultihash
-    )
+    const carBytesFromPackStore = await packStore.get(packMultihash)
     assert(carBytesFromPackStore)
     assert(equals(carBytesFromPackStore, readBytes))
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       '@hash-stream/eslint-config':
         specifier: workspace:^
         version: link:../eslint-config
+      '@hash-stream/streamer':
+        specifier: workspace:^
+        version: link:../streamer
       '@storacha/one-webcrypto':
         specifier: ^1.0.1
         version: 1.0.1


### PR DESCRIPTION
Provides a way to stream file data from multiple pack stores depending on the input type (multihash digest or path). This is useful for keeping original raw files in a separate store and UnixFS Dag files in another store.