### PR TITLE
feat: add support for inline blob index record

### DIFF
--- a/docs/src/content/docs/api/@hash-stream/cli/variables/TypeStr.md
+++ b/docs/src/content/docs/api/@hash-stream/cli/variables/TypeStr.md
@@ -5,6 +5,6 @@ prev: true
 title: "TypeStr"
 ---
 
-> `const` **TypeStr**: [`Readonly`](https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype)\<\{ `0`: `"BLOB"`; `1`: `"PACK"`; `2`: `"CONTAINING"`; \}\>
+> `const` **TypeStr**: [`Readonly`](https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype)\<\{ `0`: `"BLOB"`; `1`: `"PACK"`; `2`: `"CONTAINING"`; `3`: `"INLINE_BLOB"`; \}\>
 
 Defined in: [index.js:317](https://github.com/vasco-santos/hash-stream/blob/main/packages/cli/src/index.js#L317)

--- a/docs/src/content/docs/api/@hash-stream/streamer/enumerations/Type.md
+++ b/docs/src/content/docs/api/@hash-stream/streamer/enumerations/Type.md
@@ -5,7 +5,7 @@ prev: true
 title: "Type"
 ---
 
-Defined in: [index.js:168](https://github.com/vasco-santos/hash-stream/blob/main/packages/streamer/src/index.js#L168)
+Defined in: [index.js:185](https://github.com/vasco-santos/hash-stream/blob/main/packages/streamer/src/index.js#L185)
 
 ## Enumeration Members
 
@@ -13,4 +13,4 @@ Defined in: [index.js:168](https://github.com/vasco-santos/hash-stream/blob/main
 
 > **PLAIN**: `0`
 
-Defined in: [index.js:169](https://github.com/vasco-santos/hash-stream/blob/main/packages/streamer/src/index.js#L169)
+Defined in: [index.js:186](https://github.com/vasco-santos/hash-stream/blob/main/packages/streamer/src/index.js#L186)

--- a/docs/src/content/docs/specs/index.mdx
+++ b/docs/src/content/docs/specs/index.mdx
@@ -73,13 +73,16 @@ type IndexRecord = {
 }
 
 // Record Type Enum
-type IndexRecordType = BLOB | PACK | CONTAINING
+type IndexRecordType = BLOB | PACK | CONTAINING | INLINE_BLOB
 type BLOB = 0
 type PACK = 1
 type CONTAINING = 2
+type INLINE_BLOB = 3
 
 type Path = string
 ```
+
+It is worth pointing out that when an index record is of type **INLINE_BLOB**, the location is the hash digest of the raw Blob as identity multihash.
 
 ### Index Store Reader
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -318,6 +318,7 @@ export const TypeStr = Object.freeze({
   0: 'BLOB',
   1: 'PACK',
   2: 'CONTAINING',
+  3: 'INLINE_BLOB',
 })
 
 /**

--- a/packages/index/src/record.js
+++ b/packages/index/src/record.js
@@ -1,5 +1,6 @@
 import * as API from './api.js'
 
+import { identity } from 'multiformats/hashes/identity'
 import { decode as decodeDigest } from 'multiformats/hashes/digest'
 
 /**
@@ -94,10 +95,25 @@ export function createFromBlob(multihash, location, offset, length) {
 }
 
 /**
+ * @param {API.MultihashDigest} multihash
+ * @param {Uint8Array} rawBlob
+ * @param {number} offset
+ * @param {number} length
+ */
+export function createFromInlineBlob(multihash, rawBlob, offset, length) {
+  const digest = identity.digest(rawBlob)
+  return new IndexRecord(multihash, Type.INLINE_BLOB, digest, [], {
+    offset,
+    length,
+  })
+}
+
+/**
  * @enum {API.IndexRecordType}
  */
 export const Type = Object.freeze({
   BLOB: /** @type {API.IndexRecordType} */ (0),
   PACK: /** @type {API.IndexRecordType} */ (1),
   CONTAINING: /** @type {API.IndexRecordType} */ (2),
+  INLINE_BLOB: /** @type {API.IndexRecordType} */ (3),
 })

--- a/packages/index/test/helpers/random.js
+++ b/packages/index/test/helpers/random.js
@@ -71,11 +71,19 @@ export async function randomBlob(size) {
   return { digest, size: blobSize, cid }
 }
 
-// eslint-disable-next-line
-export async function randomCID() {
-  const bytes = await randomBytes(10)
+/**
+ * @param {object} options
+ * @param {Uint8Array} [options.bytes] - Bytes to use for the CID, if not provided a random 10 byte value will be used.
+ * @returns {Promise<CID>} A CID with a raw codec and sha256 hash.
+ */
+export async function randomCID(options = {}) {
+  let bytes = options.bytes
+  if (!bytes) {
+    bytes = await randomBytes(10)
+  }
   const hash = await sha256.digest(bytes)
   return CID.create(1, raw.code, hash)
 }
 
+// eslint-disable-next-line
 export const CarCode = 0x0202

--- a/packages/index/test/reader.js
+++ b/packages/index/test/reader.js
@@ -1,16 +1,18 @@
 import assert from 'assert'
 import { equals } from 'uint8arrays'
 import all from 'it-all'
+import { identity } from 'multiformats/hashes/identity'
 
 import {
   Type,
   createFromBlob,
   createFromPack,
   createFromContaining,
+  createFromInlineBlob,
 } from '../src/record.js'
 import { recordType } from '../src/writer/multiple-level.js'
 
-import { randomCID } from './helpers/random.js'
+import { randomBytes, randomCID } from './helpers/random.js'
 
 /**
  * @typedef {import('@hash-stream/index/types').IndexReader} IndexReader
@@ -83,6 +85,37 @@ export function runIndexReaderTests(indexReaderName, createIndexReader) {
       assert(typeof records[0].location !== 'string')
       assert(equals(records[0].location.digest, packCid.multihash.digest))
       assert(records[0].type === Type.BLOB)
+    })
+
+    it('can find index record for inline stored blob', async () => {
+      const bytes = await randomBytes(100)
+      const blobCid = await randomCID({ bytes })
+      const { digest } = identity.digest(bytes)
+
+      const offset = 0
+      const length = 100
+
+      const blob = createFromInlineBlob(
+        blobCid.multihash,
+        bytes,
+        offset,
+        length
+      )
+
+      await indexReader.storeWriter.add(
+        (async function* () {
+          yield blob
+        })(),
+        recordType
+      )
+
+      const records = await all(indexReader.findRecords(blobCid.multihash))
+      assert(records.length === 1)
+      assert.strictEqual(records[0].offset, offset)
+      assert.strictEqual(records[0].length, length)
+      assert(typeof records[0].location !== 'string')
+      assert(equals(records[0].location.digest, digest))
+      assert(records[0].type === Type.INLINE_BLOB)
     })
 
     it('can retrieve a containing index record with a pack composed by two Blobs', async () => {

--- a/packages/index/test/store.js
+++ b/packages/index/test/store.js
@@ -102,7 +102,7 @@ export function runIndexStoreTests(storeName, createIndexStore) {
       assert.deepEqual(retrieved, [])
     })
 
-    it.only('can store and retrieve inline blob index record', async () => {
+    it('can store and retrieve inline blob index record', async () => {
       const bytes = await randomBytes(100)
       const blobCid = await randomCID({ bytes })
       const { digest } = identity.digest(bytes)

--- a/packages/index/test/store.js
+++ b/packages/index/test/store.js
@@ -2,16 +2,18 @@ import assert from 'assert'
 
 import { equals } from 'uint8arrays'
 import all from 'it-all'
+import { identity } from 'multiformats/hashes/identity'
 
 import {
   Type,
   createFromBlob,
   createFromPack,
   createFromContaining,
+  createFromInlineBlob,
 } from '../src/record.js'
 import { recordType } from '../src/writer/multiple-level.js'
 
-import { randomCID } from './helpers/random.js'
+import { randomBytes, randomCID } from './helpers/random.js'
 
 /**
  * @typedef {import('@hash-stream/index/types').IndexStore} IndexStore
@@ -98,6 +100,38 @@ export function runIndexStoreTests(storeName, createIndexStore) {
       const blockCid = await randomCID()
       const retrieved = await all(store.get(blockCid.multihash))
       assert.deepEqual(retrieved, [])
+    })
+
+    it.only('can store and retrieve inline blob index record', async () => {
+      const bytes = await randomBytes(100)
+      const blobCid = await randomCID({ bytes })
+      const { digest } = identity.digest(bytes)
+
+      const offset = 0
+      const length = 100
+
+      const blob = createFromInlineBlob(
+        blobCid.multihash,
+        bytes,
+        offset,
+        length
+      )
+
+      await store.add(
+        (async function* () {
+          yield blob
+        })(),
+        recordType
+      )
+
+      const records = await all(store.get(blob.multihash))
+      assert(records.length === 1)
+      assert.strictEqual(records[0].offset, offset)
+      assert.strictEqual(records[0].length, length)
+      assert(typeof records[0].location !== 'string')
+      assert(equals(records[0].location.digest, digest))
+      assert(equals(records[0].location.digest, bytes))
+      assert(records[0].type === Type.INLINE_BLOB)
     })
 
     it('can handle large offsets and lengths', async () => {

--- a/packages/streamer/src/index.js
+++ b/packages/streamer/src/index.js
@@ -79,6 +79,23 @@ export class HashStreamer {
       } else if (record.type === IndexRecordType.CONTAINING) {
         // CONTAINING
         yield* this.#processIndexRecords(record.subRecords, seenMultihashes)
+      } else if (record.type === IndexRecordType.INLINE_BLOB) {
+        // INLINE_BLOB
+
+        // Skip duplicates
+        /* c8 ignore next 1 */
+        if (seenMultihashes.has(record.multihash)) continue
+        // Skip if location is a string given it would not be a valid inline blob
+        /* c8 ignore next 1 */
+        if (typeof record.location === 'string') continue
+
+        // Yield inline blob directly as location is encoded as identity multihash
+        yield {
+          multihash: record.multihash,
+          bytes: record.location.digest,
+          type: Type.PLAIN,
+        }
+        seenMultihashes.add(record.multihash)
       }
     }
 

--- a/packages/streamer/test/helpers/random.js
+++ b/packages/streamer/test/helpers/random.js
@@ -20,10 +20,15 @@ export async function randomBytes(size) {
 }
 
 /**
- * @returns {Promise<CID>}
+ * @param {object} options
+ * @param {Uint8Array} [options.bytes] - Bytes to use for the CID, if not provided a random 10 byte value will be used.
+ * @returns {Promise<CID>} A CID with a raw codec and sha256 hash.
  */
-export async function randomCID() {
-  const bytes = await randomBytes(10)
+export async function randomCID(options = {}) {
+  let bytes = options.bytes
+  if (!bytes) {
+    bytes = await randomBytes(10)
+  }
   const hash = await sha256.digest(bytes)
   return CID.create(1, raw.code, hash)
 }


### PR DESCRIPTION
We extend index record with new type to support inline blob index record to support use cases like relying on indexes from Singularity